### PR TITLE
Fixed JS files were compressed twice and licence comment was stripped.

### DIFF
--- a/tasks/_scripts.js
+++ b/tasks/_scripts.js
@@ -32,14 +32,12 @@ module.exports = function(config, pkg) {
     const handleErrors = require('../utils/handleErrors');
     const replace = require('gulp-replace');
     const sourcemaps = require('gulp-sourcemaps');
-    const uglify = require('gulp-uglify');
 
     const task = gulp.src(config.src.js)
         .pipe(changed(config.dist.main, {extension: '.js'}))
         .pipe(gulpIf(!isProduction, sourcemaps.init()))
         .pipe(babel())
         .pipe(replace(copyrightPlaceholder, copyrightNotice))
-        .pipe(gulpIf(isProduction, uglify()))
         .pipe(gulpIf(!isProduction, sourcemaps.write(config.sourcemaps)))
         .on('error', handleErrors)
         .pipe(gulp.dest(config.tmp.scripts));

--- a/tasks/_templates.js
+++ b/tasks/_templates.js
@@ -57,7 +57,11 @@ module.exports = function(config) {
     return gulp.src(config.tmp.templates)
         .pipe(useref())
         .pipe(gulpIf(isProduction && '*.css', cleanCSS()))
-        .pipe(gulpIf(isProduction && '*.js', uglify()))
+        .pipe(gulpIf(isProduction && '*.js', uglify({
+          output: {
+            comments: '/^!/',
+          },
+        })))
         .pipe(gulpIf(isProduction && '!index.html', rev()))
         .pipe(gulpIf(isProduction && '*.css', rename({
           suffix: '.min',


### PR DESCRIPTION
## Checklist for this Pull Request

- [x] Check if a related or similar issue already exists. If not, please create one.
- [x] Check if the added code and commits messages match our requested style and structure.
- [x] Check that your code additions will not fail code linting checks.
- [x] Check that the package fully works if installed into a sample static website.

## Related Issue

- [JavaScript files minified twice and licence comment is stripped](https://github.com/LucaPipolo/gulp-static-starterkit/issues/10)
