### PR TITLE
Fixed gulp build was failing if .htaccess or google-fonts.list files …

### DIFF
--- a/tasks/_copy.js
+++ b/tasks/_copy.js
@@ -11,7 +11,9 @@ module.exports = function(config) {
   gulp.task('copy:htaccess', function() {
     const copy = require('gulp-copy');
 
-    const task = gulp.src(config.src.main + '.htaccess')
+    const task = gulp.src(config.src.main + '.htaccess', {
+      allowEmpty: true,
+    })
         .pipe(copy(config.dist.main, {
           prefix: 1,
         }))

--- a/tasks/_fonts.js
+++ b/tasks/_fonts.js
@@ -11,7 +11,9 @@ module.exports = function(config) {
   gulp.task('fonts:google', function() {
     const googleWebFonts = require('gulp-google-webfonts');
 
-    const task = gulp.src(config.src.fonts + '/google-fonts.list')
+    const task = gulp.src(config.src.fonts + '/google-fonts.list', {
+      allowEmpty: true,
+    })
         .pipe(googleWebFonts({fontsDir: '../fonts'}))
         .pipe(gulp.dest(config.dist.fonts));
     return task;


### PR DESCRIPTION
…were missing.

## Checklist for this Pull Request

- [x] Check if a related or similar issue already exists. If not, please create one.
- [x] Check if the added code and commits messages match our requested style and structure.
- [x] Check that your code additions will not fail code linting checks.
- [x] Check that the package fully works if installed into a sample static website.

## Related Issue

- [Gulp build fails if google-fonts.list file is not in src/fonts folder](https://github.com/LucaPipolo/gulp-static-starterkit/issues/13)
- [Gulp build fails if .htaccess file is not in src folder](https://github.com/LucaPipolo/gulp-static-starterkit/issues/12)
